### PR TITLE
🐛 Fix local Traefik proxy network config to fix Gateway Timeouts 

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -24,6 +24,9 @@ services:
       - traefik.http.routers.traefik-dashboard-http.service=api@internal
       - traefik.http.middlewares.admin-auth.basicauth.users=${USERNAME?Variable not set}:${HASHED_PASSWORD?Variable not set}
       - traefik.http.routers.traefik-dashboard-http.middlewares=admin-auth
+    networks:
+      - traefik-public
+      - default
 
   frontend:
     build:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -35,6 +35,9 @@ services:
       # Dummy https-redirect middleware that doesn't really redirect, only to
       # allow running it locally
       - traefik.http.middlewares.https-redirect.contenttype.autodetect=false
+    networks:
+      - traefik-public
+      - default
 
   db:
     restart: "no"


### PR DESCRIPTION
The network config of the proxy service for the local docker setup (docker-compose.override.yaml and docker-compose.local.yaml) is missing and therefore the proxy service can't reach the backend service (produces Gateway Timeouts).