### PR TITLE
Fix read threads result order

### DIFF
--- a/backend/app/api/routes/threads.py
+++ b/backend/app/api/routes/threads.py
@@ -61,6 +61,7 @@ def read_threads(
             .where(Team.owner_id == current_user.id, Thread.team_id == team_id)
             .offset(skip)
             .limit(limit)
+            .order_by(col(Thread.updated_at).desc())
         )
         threads = session.exec(statement).all()
     return ThreadsOut(data=threads, count=count)


### PR DESCRIPTION
Threads listed in threads page is not in descending order for non-admins