### PR TITLE
Remove unused serpapi variables in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,9 +35,6 @@ SPARSE_EMBEDDING_MODEL=prithivida/Splade_PP_en_v1
 LANGCHAIN_TRACING_V2=
 LANGCHAIN_API_KEY=
 
-# tools/skills api keys
-SERP_API_KEY=
-SERPAPI_API_KEY=
 
 # Emails
 SMTP_HOST=


### PR DESCRIPTION
Remove unused serpapi variables from `.env.example` to reduce confusion.