### PR TITLE
Set max-memory-per-child value for celery to fix memory leak issue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,6 @@ QDRANT__SERVICE__API_KEY=changethis
 
 # Flower
 FLOWER_BASIC_AUTH=admin:changethis
+
+# Celery
+MAX_MEMORY_PER_CHILD='512000' # Useful for potential memory leaks - default 500MB

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
     volumes:
       - app-backend-model-cache:/app/cache
       - app-upload-data:/app/upload-data
-    command: poetry run celery -A app.core.celery_app.celery_app worker --loglevel=info --uid=celery --gid=celery
+    command: poetry run celery -A app.core.celery_app.celery_app worker --loglevel=info --uid=celery --gid=celery --max-memory-per-child=${MAX_MEMORY_PER_CHILD?Varible not set}
     depends_on:
       - redis
       - backend


### PR DESCRIPTION
Fix potential memory leak issue in celery container by setting a max memory limit for the celery worker process so that it is replaced if memory exceeds.