### PR TITLE
Fix bug with self.final_answer_model in members.py to resolve model configuration inconsistencies

### DIFF
--- a/backend/app/core/graph/members.py
+++ b/backend/app/core/graph/members.py
@@ -174,9 +174,7 @@ class BaseNode:
             self.model = init_chat_model(
                 model, model_provider=provider, temperature=0, streaming=True
             )
-        self.final_answer_model = init_chat_model(
-            model, model_provider=provider, temperature=0, streaming=True
-        )
+        self.final_answer_model = self.model
 
     def tag_with_name(self, ai_message: AIMessage, name: str) -> AIMessage:
         """Tag a name to the AI message"""


### PR DESCRIPTION
fix final_answer_model in members.py to use the model configuration provided by user to resolve issues with configuration inconsistency between member models & final model.

This resolves issues where a user may specify the ollama model or any model that requires custom parameters like "base_url" that fail to be properly configured in the final_answer_model object thus resulting in errors (potentially due to final_answer_model resolving the wrong model to be used or due to it using defaults due to missing parameter configurations).  